### PR TITLE
Fix hover selector for input class

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -67,7 +67,7 @@
         }
 
         .input:focus,
-        input:hover {
+        .input:hover {
           outline: none;
           border-color: rgba(71, 99, 255, 0.46);
           background-color: #fff;


### PR DESCRIPTION
## Summary
- Restrict hover styles to elements with the `.input` class to avoid unintentional global input styling

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a6ebb7863083228ec9e92cfd4d66b9